### PR TITLE
Feature: Added Random Mesh Gradient Background & LinkedIn Banner Ratio

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"eslint": "^8.51.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte": "^2.34.0",
+		"meshgrad": "^0.0.15",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.10.1",
 		"sass": "^1.69.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ devDependencies:
   eslint-plugin-svelte:
     specifier: ^2.34.0
     version: 2.34.0(eslint@8.51.0)(svelte@4.2.2)
+  meshgrad:
+    specifier: ^0.0.15
+    version: 0.0.15
   prettier:
     specifier: ^2.8.0
     version: 2.8.0
@@ -1967,6 +1970,10 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /meshgrad@0.0.15:
+    resolution: {integrity: sha512-qvu+I92Uu5I5iKrkiWcmEu0IpkBI/jgIsks7P1HQ5vYaD6SQC9W8WHxUIOeQ2zpdxoomjSpO4rZ8m4UIF4qwfQ==}
     dev: true
 
   /micromatch@4.0.5:

--- a/src/lib/components/RegenerateGradientButton.svelte
+++ b/src/lib/components/RegenerateGradientButton.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { generateMeshGradient } from 'meshgrad';
+
+	/**
+	 * Represents 2 properties.
+     * 1. background-color : hsl(XXX, XXX%, XX%)
+     * 2. background-image : radial-gradient(...)
+     * Both are converted to string format (combined)
+	 */
+	export let value: string | null;
+</script>
+
+<button
+	aria-label="Refresh"
+	on:click={async () => {
+		value = generateMeshGradient(6);
+	}}
+>
+	<span class="block i-tabler-refresh" aria-hidden />
+</button>
+
+<style lang="scss">
+	button {
+		@include border-gradient;
+		--p-border-radius: 0.5rem;
+		--p-border-gradient-before: linear-gradient(
+			to bottom,
+			hsl(var(--color-white-hsl) / 0.12) 0%,
+			hsl(var(--color-white-hsl) / 0) 100%
+		);
+
+		background: hsl(var(--color-white-hsl) / 0.08);
+
+		--p-size: 2.5rem;
+		width: var(--p-size);
+		height: var(--p-size);
+		display: grid;
+		place-items: center;
+
+		transition: 150ms ease;
+
+		&:hover {
+			background: hsl(var(--color-white-hsl) / 0.12);
+		}
+
+		&:active {
+			background: hsl(var(--color-white-hsl) / 0.1);
+		}
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 	import { melt, type SelectOption } from '@melt-ui/svelte';
 	import { tick } from 'svelte';
 	import { fly } from 'svelte/transition';
+	import RegenerateGradientButton from '$lib/components/RegenerateGradientButton.svelte';
 
 	// Options
 	const langOptions: SelectOption<LanguagePreset>[] = [
@@ -59,6 +60,10 @@
 		{
 			label: 'Stories (IG, LinkedIn)',
 			value: '1080/1920'
+		},
+		{
+			label: 'LinkedIn Banner',
+			value: '1584/396'
 		}
 	];
 	let ratio = ratios[0].value;
@@ -68,11 +73,13 @@
 
 	const bgOptions: SelectOption<string>[] = [
 		{ label: 'BG Dark 1', value: 'bg-1.png' },
-		{ label: 'Custom', value: 'custom' }
+		{ label: 'Custom', value: 'custom' },
+		{ label: 'Random Mesh Gradient', value: 'random_mesh_gradient' },
 	];
 
 	let bg = bgOptions[1].value;
 	let customBg: string | null = null;
+	let randomGradientValue: string | null = null;
 
 	// Debug Info
 	$: trueRatio = (() => {
@@ -129,7 +136,13 @@
 			</div>
 		{/if}
 
-		<Popover>
+		{#if bg === 'random_mesh_gradient'}
+			<div class="self-end" transition:fly={{ duration: 150, y: 4 }}>
+				<RegenerateGradientButton bind:value={randomGradientValue} />
+			</div>
+		{/if}
+
+		<Popover> 	
 			<button
 				slot="trigger"
 				let:trigger
@@ -197,6 +210,7 @@
 			style:--p-ratio={ratio}
 			style:--p-resize={capturing ? 'none' : 'both'}
 			style:--p-bg="url({bg === 'custom' ? customBg : `/images/${bg}`})"
+			style={bg === 'random_mesh_gradient' ? randomGradientValue : null}
 		>
 			<div class="code-window" style:--p-scale={scale}>
 				<div class="flex gap-8 mis-8">


### PR DESCRIPTION
I raised an issue about feature request #1 where I mentioned why we require this feature.
## Implementation Details of #1 
---
### Modified Files
- package.json
  - added `meshgrad` as devDependencies ([meshgrad](https://www.npmjs.com/package/meshgrad) is a lightweight package that is used to generate mesh gradient CSS properties.)
  - pnpm-lock.json
- src/route/+page.svelte
  - Added LinkedBanner in the `ratios` list with its dimensions
  - Added `Random Mesh Gradient` in `bgOptions`
  - Added Styling for applying gradient properties on the background 
  
### New Created Files
- src/lib/components/RegenerateGradientButton.svelte
  - Button same as `InputImage`
---
### Result of Implementation
![image](https://github.com/appwrite/snapwrite/assets/72139914/cc9ac370-bb22-42dd-9798-3d8c242d6f88)
![image](https://github.com/appwrite/snapwrite/assets/72139914/57fec0a2-0112-452b-8ab7-016cdb731aaf)

### Why do we need this feature & How it's useful?
- As I already mentioned the requirement in issue #1, It makes the code look stunning if there is a colorful mesh gradient background as shown in the result section.

Let me know in case more info is needed!
Thanks!